### PR TITLE
Parse 8-byte ASCII hex values for last save timestamp as per Password Safe file format spec

### DIFF
--- a/src/pypwsafe/PWSafeV3Headers.py
+++ b/src/pypwsafe/PWSafeV3Headers.py
@@ -37,6 +37,7 @@ import os
 import logging, logging.config
 from uuid import UUID, uuid4
 from pprint import pformat
+from binascii import unhexlify
 
 #logging.config.fileConfig('/etc/mss/psafe_log.conf')
 log = logging.getLogger("psafe.lib.header")
@@ -368,7 +369,10 @@ lastsave    time struct        Last save time of DB
 
     def parse(self):
         """Parse data"""
-        self.lastsave = time.gmtime(unpack('=i', self.data)[0])
+        time_data = self.data
+        if len(time_data) == 8:
+            time_data = unhexlify(time_data)
+        self.lastsave = time.gmtime(unpack('=i', time_data)[0])
 
     def __repr__(self):
         return "LastSave" + Header.__repr__(self)


### PR DESCRIPTION
I'm passing along a small patch to add 8-byte ASCII hex value parsing for the last save timestamp header, as suggested by the Password Safe file format spec. This appears to fix compatibility issues with files created by the Android version of PasswdSafe (or at least the version I used when I first created my password file :-) ).
